### PR TITLE
fix: GitHub settings modal positioning with React Portal

### DIFF
--- a/src/components/GitHubSettingsModal.tsx
+++ b/src/components/GitHubSettingsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   getGitHubSyncConfig,
   setGitHubSyncConfig,
@@ -35,6 +36,12 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
   const [isConnected, setIsConnected] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  // Mount portal on client side only
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   // Load existing config on mount, or pre-fill with detected repo
   useEffect(() => {
@@ -124,9 +131,12 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
     setTestResult(null);
   };
 
-  if (!isOpen) return null;
+  // Don't render until mounted (client-side) or if not open
+  if (!mounted || !isOpen) return null;
 
-  return (
+  // Use portal to render at document body level, bypassing any parent transforms/filters
+  // that could break fixed positioning (e.g., backdrop-blur on Header)
+  const modalContent = (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
@@ -135,9 +145,9 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
       />
 
       {/* Modal */}
-      <div className="relative w-full max-w-lg bg-surface-900 rounded-2xl shadow-2xl border border-surface-700 overflow-hidden">
+      <div className="relative w-full max-w-lg max-h-[90vh] mx-4 my-4 bg-surface-900 rounded-2xl shadow-2xl border border-surface-700 overflow-hidden flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-surface-800 flex-shrink-0">
           <div className="flex items-center gap-3">
             <svg className="w-6 h-6 text-surface-300" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
@@ -160,7 +170,7 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-5">
+        <div className="p-6 space-y-5 overflow-y-auto flex-1">
           {/* Personal Access Token */}
           <div>
             <label className="block text-sm font-medium text-surface-200 mb-2">
@@ -271,7 +281,7 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-between px-6 py-4 border-t border-surface-800 bg-surface-800/30">
+        <div className="flex items-center justify-between px-6 py-4 border-t border-surface-800 bg-surface-800/30 flex-shrink-0">
           {isConnected ? (
             <button
               onClick={handleDisconnect}
@@ -302,4 +312,6 @@ export function GitHubSettingsModal({ isOpen, onClose, onConnect, detectedRepo }
       </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 }

--- a/src/components/StorageModeSelector.tsx
+++ b/src/components/StorageModeSelector.tsx
@@ -55,6 +55,7 @@ export function StorageModeSelector({ onModeChange, onExport, compact = false, d
   const handleModeSelect = (mode: StorageMode) => {
     // If selecting GitHub mode and not configured, open settings first
     if (mode === 'github' && !isGitHubConfigured) {
+      setIsOpen(false); // Close dropdown before opening modal
       setIsGitHubModalOpen(true);
       return;
     }


### PR DESCRIPTION
## Summary
- Fix GitHub settings modal being cut off at top of viewport
- Modal was rendered inside Header which has `backdrop-blur`, creating a new containing block that broke `fixed` positioning
- Now uses React Portal (`createPortal`) to render at `document.body` level

## Test plan
- [ ] Click Storage Mode dropdown → GitHub Issues
- [ ] Verify modal appears centered with all fields visible:
  - GitHub Issues Sync header
  - Personal Access Token input
  - Repository field (auto-detected)
  - Test Connection / Connect buttons
- [ ] Test on smaller viewports - modal should scroll if needed