### PR TITLE
Task brief should render in markdown

### DIFF
--- a/src/components/DeleteConfirmationModal.tsx
+++ b/src/components/DeleteConfirmationModal.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type { BacklogItem } from '@/types/backlog';
+import { cleanDescriptionForDisplay } from '@/lib/display-utils';
 
 interface DeleteConfirmationModalProps {
   /** The item to be deleted */
@@ -13,15 +16,6 @@ interface DeleteConfirmationModalProps {
   onCancel: () => void;
 }
 
-/**
- * Clean description text by removing HTML comments and metadata
- */
-function cleanDescription(text: string | undefined): string | undefined {
-  if (!text) return undefined;
-  // Remove HTML comments (e.g., <!-- ringmaster-task-id:xxx -->)
-  const cleaned = text.replace(/<!--[\s\S]*?-->/g, '').trim();
-  return cleaned || undefined;
-}
 
 /**
  * Confirmation modal shown before deleting a task via drag-and-drop.
@@ -34,7 +28,7 @@ export function DeleteConfirmationModal({
 }: DeleteConfirmationModalProps) {
   if (!isOpen || !item) return null;
 
-  const cleanedDescription = cleanDescription(item.description);
+  const cleanedDescription = cleanDescriptionForDisplay(item.description);
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
@@ -65,7 +59,11 @@ export function DeleteConfirmationModal({
           <div className="bg-surface-800/50 rounded-lg p-4 border border-surface-700">
             <h3 className="font-medium text-surface-200 line-clamp-2">{item.title}</h3>
             {cleanedDescription && (
-              <p className="text-sm text-surface-400 mt-2 line-clamp-2">{cleanedDescription}</p>
+              <div className="text-sm text-surface-400 mt-2 line-clamp-2 prose prose-invert prose-sm max-w-none prose-p:m-0 prose-headings:text-surface-300 prose-headings:text-xs prose-headings:font-medium prose-headings:m-0 prose-strong:text-surface-300 prose-code:text-accent prose-code:text-[10px] prose-code:bg-surface-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-ul:m-0 prose-ul:list-inside prose-li:m-0 prose-a:text-accent prose-a:no-underline hover:prose-a:underline">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {cleanedDescription}
+                </ReactMarkdown>
+              </div>
             )}
             <div className="flex items-center gap-2 mt-3">
               <span className={`px-2 py-0.5 rounded text-xs font-medium ${

--- a/src/components/TackleModal.tsx
+++ b/src/components/TackleModal.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type { BacklogItem } from '@/types/backlog';
 import { useIdeSettings, IDE_OPTIONS, type IdeType } from '@/hooks/useIdeSettings';
 import { buildTaskPrompt, buildConversationalPrompt } from '@/lib/prompt-builder';
@@ -324,9 +326,39 @@ export function TackleModal({ item, isOpen, onClose, onStartWork, onShowToast, b
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-6">
-          <pre className="whitespace-pre-wrap text-sm text-surface-300 font-mono leading-relaxed">
-            {mode === 'plan' ? generatePlan() : generatePrompt()}
-          </pre>
+          <div className="prose prose-invert prose-sm max-w-none
+            prose-headings:text-surface-100 prose-headings:font-display prose-headings:font-semibold
+            prose-h1:text-lg prose-h1:mb-3 prose-h1:mt-0
+            prose-h2:text-base prose-h2:mb-2 prose-h2:mt-4
+            prose-p:text-surface-300 prose-p:leading-relaxed prose-p:mb-3
+            prose-strong:text-surface-200 prose-strong:font-semibold
+            prose-code:text-accent prose-code:text-xs prose-code:bg-surface-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
+            prose-pre:bg-surface-950 prose-pre:border prose-pre:border-surface-800 prose-pre:text-xs
+            prose-ul:text-surface-300 prose-ul:my-2 prose-li:my-1
+            prose-ol:text-surface-300 prose-ol:my-2
+            prose-a:text-accent prose-a:no-underline hover:prose-a:underline
+            prose-blockquote:border-l-accent prose-blockquote:text-surface-400"
+          >
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                // Preserve code blocks with their formatting
+                pre: ({ children, ...props }) => (
+                  <pre className="bg-surface-950 border border-surface-800 rounded-lg p-4 overflow-x-auto" {...props}>
+                    {children}
+                  </pre>
+                ),
+                // Style inline code
+                code: ({ children, ...props }) => (
+                  <code className="text-accent bg-surface-800 px-1.5 py-0.5 rounded text-xs font-mono" {...props}>
+                    {children}
+                  </code>
+                ),
+              }}
+            >
+              {mode === 'plan' ? generatePlan() : generatePrompt()}
+            </ReactMarkdown>
+          </div>
         </div>
 
         {/* Footer */}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -3,6 +3,7 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import type { BacklogItem, Priority, Status } from '@/types/backlog';
 import { QUALITY_THRESHOLD } from '@/lib/task-quality';
 import { cleanDescriptionForDisplay } from '@/lib/display-utils';
@@ -153,8 +154,8 @@ export function TaskCard({ item, onClick, isDragging, isPrioritized }: TaskCardP
 
         {/* Description preview - renders markdown, cleaned of internal metadata */}
         {item.description && (
-          <div className="text-xs text-surface-400 line-clamp-2 mb-2.5 leading-relaxed prose prose-invert prose-xs max-w-none prose-p:m-0 prose-p:leading-relaxed prose-headings:text-surface-300 prose-headings:text-xs prose-headings:font-medium prose-headings:m-0 prose-strong:text-surface-300 prose-code:text-accent prose-code:text-[10px] prose-code:bg-surface-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none">
-            <ReactMarkdown>
+          <div className="text-xs text-surface-400 line-clamp-2 mb-2.5 leading-relaxed prose prose-invert prose-xs max-w-none prose-p:m-0 prose-p:leading-relaxed prose-headings:text-surface-300 prose-headings:text-xs prose-headings:font-medium prose-headings:m-0 prose-strong:text-surface-300 prose-code:text-accent prose-code:text-[10px] prose-code:bg-surface-800 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-ul:m-0 prose-ul:list-inside prose-li:m-0 prose-a:text-accent prose-a:no-underline hover:prose-a:underline">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {cleanDescriptionForDisplay(item.description)}
             </ReactMarkdown>
           </div>

--- a/src/lib/display-utils.ts
+++ b/src/lib/display-utils.ts
@@ -37,23 +37,45 @@ const METADATA_PATTERNS = [
 ];
 
 /**
- * Strips internal metadata from a description for display in UI previews.
- * The original data is preserved - this only affects how it's shown to users.
+ * Strips internal metadata from a description while preserving markdown formatting.
+ * Use this for markdown previews where you want formatting intact.
  *
  * @param description - Raw description that may contain metadata
- * @returns Cleaned description suitable for display
+ * @returns Cleaned description with markdown preserved
  */
 export function cleanDescriptionForDisplay(description: string | undefined): string {
   if (!description) return '';
 
   let cleaned = description;
 
-  // First pass: Remove metadata patterns with markdown formatting
+  // Remove metadata patterns while preserving markdown formatting
   for (const pattern of METADATA_PATTERNS) {
     cleaned = cleaned.replace(pattern, '');
   }
 
-  // Strip markdown formatting for plain text preview
+  // Clean up excessive whitespace left after removal
+  cleaned = cleaned
+    .replace(/^\s*\n+/gm, '\n')  // Remove leading empty lines
+    .replace(/\n{3,}/g, '\n\n')  // Collapse multiple newlines
+    .trim();
+
+  return cleaned;
+}
+
+/**
+ * Strips internal metadata AND markdown formatting for plain text display.
+ * Use this when you need a truly plain text preview without any formatting.
+ *
+ * @param description - Raw description that may contain metadata
+ * @returns Plain text description suitable for non-markdown contexts
+ */
+export function stripMarkdownForDisplay(description: string | undefined): string {
+  if (!description) return '';
+
+  // First clean metadata
+  let cleaned = cleanDescriptionForDisplay(description);
+
+  // Then strip markdown formatting for plain text preview
   cleaned = cleaned
     // Remove code blocks FIRST (before inline code processing interferes)
     // Handle both ``` and `` fenced code blocks
@@ -73,12 +95,7 @@ export function cleanDescriptionForDisplay(description: string | undefined): str
     .replace(/^\s*[-*+]\s+/gm, '')
     .replace(/^\s*\d+\.\s+/gm, '');
 
-  // Second pass: Remove plain-text metadata lines (after markdown stripped)
-  for (const pattern of METADATA_PATTERNS) {
-    cleaned = cleaned.replace(pattern, '');
-  }
-
-  // Clean up excessive whitespace left after removal
+  // Clean up excessive whitespace left after stripping
   cleaned = cleaned
     .replace(/^\s*\n+/gm, '\n')  // Remove leading empty lines
     .replace(/\n{3,}/g, '\n\n')  // Collapse multiple newlines


### PR DESCRIPTION
**Description:**
Implement markdown rendering for task briefs/descriptions throughout the Bozo Parlay application to improve readability and formatting options. Currently, task descriptions appear as plain text, limiting the ability to structure information with headers, lists, code blocks, and emphasis. Adding markdown support will make task briefs more scannable and professional, especially for complex tasks that require detailed technical explanations or multi-step instructions.

**Requirements:**
- Integrate a markdown parsing library (e.g., `marked`, `react-markdown`, or `markdown-it`) into the frontend
- Render all task brief/description fields using the markdown parser
- Support common markdown syntax including headers, bold, italic, lists (ordered and unordered), code blocks, inline code, links, and blockquotes
- Ensure markdown rendering is sanitized to prevent XSS attacks (use a library like `DOMPurify` or built-in sanitization)
- Apply consistent styling to rendered markdown that matches the application's design system
- Maintain backward compatibility with existing plain text descriptions
- Ensure markdown renders correctly in all contexts where task briefs appear (task cards, detail views, modals, etc.)
- Consider adding a preview mode if users can edit task descriptions

**Technical Approach:**
Install `react-markdown` and `remark-gfm` (for GitHub Flavored Markdown support) as dependencies. Create a reusable `MarkdownRenderer` component that wraps the markdown parser with sanitization and custom styling. Update task display components (likely in `components/tasks/` or similar) to use this new renderer instead of plain text display. Add CSS classes to style markdown elements consistently with the app theme. If task editing exists, consider adding `react-simplemde-editor` or similar for a markdown editor with preview.

**Notes:**
(Additional context, links, or findings to be added by the user)